### PR TITLE
Fix tiles misaligning on maps w/ unusual bounds

### DIFF
--- a/examples/exampleProj.html
+++ b/examples/exampleProj.html
@@ -43,7 +43,7 @@
                 majorRadius: 1737400,
                 tileMapResource: {
                     // minx, miny, maxx, maxy
-                    bounds: [-1095700 - 1095600, 1095600, 1095700],
+                    bounds: [-1095700, -1095600, 1095600, 1095700],
                     origin: [-1095700, -1095600],
                     crsCode: 'IAU2000:30166,0,-89.9',
                     proj:

--- a/src/core/projection.ts
+++ b/src/core/projection.ts
@@ -122,9 +122,13 @@ export default class Projection {
     }
 
     invertY = (y: number, z: number): number => {
-        const bMin = this.crs.projection.bounds.min
+        const b = this.crs.projection.bounds
+        if (b === null || b.min.y === b.max.y || !isFinite(b.min.y)) {
+            // Map uses default projection and/or has unspecified/infinite bounds
+            return Math.pow(2, z) - y
+        }
         const s = this.crs.scale(z)
-        const max = this.crs.transformation.transform(bMin, s)
+        const max = this.crs.transformation.transform(b.min, s)
         const yMax = Math.ceil(max.y / 256) - 1
         return yMax - y
     }

--- a/src/core/projection.ts
+++ b/src/core/projection.ts
@@ -123,9 +123,9 @@ export default class Projection {
 
     invertY = (y: number, z: number): number => {
         const b = this.crs.projection.bounds
-        if (b === null || b.min.y === b.max.y || !isFinite(b.min.y)) {
-            // Map uses default projection and/or has unspecified/infinite bounds
-            return Math.pow(2, z) - y
+        if (this.tileMapResource.crsCode === 'EPSG:4326') {
+            // Map uses default projection
+            return Math.pow(2, z) - 1 - y
         }
         const s = this.crs.scale(z)
         const max = this.crs.transformation.transform(b.min, s)

--- a/src/core/projection.ts
+++ b/src/core/projection.ts
@@ -121,7 +121,13 @@ export default class Projection {
             this.radii.minor = radius || this.radii.major || this.baseRadius
     }
 
-    invertY = (y: number, z: number): number => Math.pow(2, z) - 1 - y
+    invertY = (y: number, z: number): number => {
+        const bMin = this.crs.projection.bounds.min
+        const s = this.crs.scale(z)
+        const max = this.crs.transformation.transform(bMin, s)
+        const yMax = Math.ceil(max.y / 256) - 1
+        return yMax - y
+    }
 
     toBounds = (a: XY, b: XY) => {
         const bounds = {

--- a/src/core/tiledWorld.ts
+++ b/src/core/tiledWorld.ts
@@ -497,9 +497,8 @@ export default class TiledWorld {
                     colors[p] = 0
                     colors[p + 1] = 0
                     colors[p + 2] = 0
-                    if (height < -100000) {
-                        height = -100000
-                    }
+                    height = Math.min(height, 100000)
+                    height = Math.max(height, -100000)
 
                     const tx =
                         xyz.x +


### PR DESCRIPTION
Makes `projection.invertY` projection-aware to support map boundaries with non-zero minimums.